### PR TITLE
Fix logging for TSIC pin in dump_config

### DIFF
--- a/components/tsic/tsic.cpp
+++ b/components/tsic/tsic.cpp
@@ -10,7 +10,7 @@ static const char *const TAG = "tsic";
 
 void TSIC::dump_config() {
     ESP_LOGCONFIG(TAG,  "TSIC:");
-    LOG_PIN("  Pin: ", this->pin_)
+    LOG_PIN("  Pin: ", this->pin_);
     ESP_LOGCONFIG(TAG,  "  Model: %i", this->model_);
     LOG_UPDATE_INTERVAL(this);
 }


### PR DESCRIPTION
Added missing ';' at the end of line